### PR TITLE
command fix for deploying contracts

### DIFF
--- a/pingPongExample/README.md
+++ b/pingPongExample/README.md
@@ -28,7 +28,7 @@ This script will deploy a contract on 2 networks, a message sender and a message
 As example for goerli testnet:
 
 ```
-npm run deploy:PingPong:goerli
+npm run deploy:pingPong:goerli
 ```
 
 In the deployment we will find the results on `pingPong_output.json`


### PR DESCRIPTION
corrected the deploy command letter casing

```
steph pingPongExample % npm run deploy:PingPong:goerli
npm ERR! Missing script: "deploy:PingPong:goerli"
npm ERR!
```